### PR TITLE
Implement Packet Receipts

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -5,9 +5,11 @@ import (
 )
 
 type NodeAddress string
+type PacketHash string
 
 type Packet interface {
 	Destination() NodeAddress
+	Hash() PacketHash
 }
 
 // A map of a fixed size representing an interfaces potential
@@ -37,7 +39,7 @@ type ReceiptConnection interface {
 // While the two connections use different messages, a working ControlConnection has both interfaces
 type ControlConnection interface {
 	MapConnection
-	//ReceiptConnection
+	ReceiptConnection
 }
 
 // The actual data connection. Should be done at the layer two level in order to be able to send congestion signals

--- a/interfaces.go
+++ b/interfaces.go
@@ -22,8 +22,9 @@ type ReachabilityMap interface {
 
 // A receipt listing packets which have been succesfully delivered
 type PacketReceipt interface {
-	ListPackets() []string
-	Verify(p NodeAddress) error
+	ListPackets() []PacketHash
+	Source() NodeAddress
+	Verify() error
 }
 
 // Layer three interfaces for network control traffic

--- a/receipt_handler.go
+++ b/receipt_handler.go
@@ -1,5 +1,10 @@
 package node
 
+import (
+	"log"
+	"sync"
+)
+
 // Takes care of maintaining maps and insures that we know which interfaces are reachable where.
 type ReceiptHandler interface {
 	AddConnection(NodeAddress, ReceiptConnection)
@@ -13,15 +18,59 @@ type packetRecord struct {
 	hash        PacketHash
 }
 
-type recieptImpl struct {
+type ReceiptAction interface {
+	Receipt(PacketHash)
+}
+
+type receiptImpl struct {
 	connections map[NodeAddress]ReceiptConnection
 	packets     map[PacketHash]packetRecord
+	l           *sync.Mutex
+	a           ReceiptAction
+}
+
+func newReceiptImpl(a ReceiptAction) ReceiptHandler {
+	return &receiptImpl{make(map[NodeAddress]ReceiptConnection), make(map[PacketHash]packetRecord), &sync.Mutex{}, a}
 }
 
 func (r *receiptImpl) AddConnection(id NodeAddress, c ReceiptConnection) {
+	r.l.Lock()
 	r.connections[id] = c
+	r.l.Unlock()
+	go func() {
+		for receipt := range c.PacketReceipts() {
+			if receipt.Verify() != nil {
+				log.Printf("Error verifying receipt: %q", receipt.Verify())
+				continue
+			}
+			dest := make(map[NodeAddress]bool)
+			r.l.Lock()
+			for _, hash := range receipt.ListPackets() {
+				record, ok := r.packets[hash]
+				if !ok {
+					log.Printf("No record found %q", hash)
+					continue
+				}
+				if record.destination != receipt.Source() {
+					log.Printf("Invalid source %q != %q", record.src, receipt.Source())
+					continue
+				}
+				if record.next != id {
+					log.Printf("Received packet receipt from wrong host? %q", id)
+				}
+				dest[record.src] = true
+				r.a.Receipt(hash)
+			}
+			for addr, _ := range dest {
+				r.connections[addr].SendReceipt(receipt)
+			}
+			r.l.Unlock()
+		}
+	}()
 }
 
 func (r *receiptImpl) AddSentPacket(p Packet, src, next NodeAddress) {
+	r.l.Lock()
+	defer r.l.Unlock()
 	r.packets[p.Hash()] = packetRecord{p.Destination(), next, src, p.Hash()}
 }

--- a/receipt_handler.go
+++ b/receipt_handler.go
@@ -1,0 +1,27 @@
+package node
+
+// Takes care of maintaining maps and insures that we know which interfaces are reachable where.
+type ReceiptHandler interface {
+	AddConnection(NodeAddress, ReceiptConnection)
+	AddSentPacket(p Packet, src, next NodeAddress)
+}
+
+type packetRecord struct {
+	destination NodeAddress
+	src         NodeAddress
+	next        NodeAddress
+	hash        PacketHash
+}
+
+type recieptImpl struct {
+	connections map[NodeAddress]ReceiptConnection
+	packets     map[PacketHash]packetRecord
+}
+
+func (r *receiptImpl) AddConnection(id NodeAddress, c ReceiptConnection) {
+	r.connections[id] = c
+}
+
+func (r *receiptImpl) AddSentPacket(p Packet, src, next NodeAddress) {
+	r.packets[p.Hash()] = packetRecord{p.Destination(), next, src, p.Hash()}
+}

--- a/receipt_handler.go
+++ b/receipt_handler.go
@@ -9,6 +9,7 @@ import (
 type ReceiptHandler interface {
 	AddConnection(NodeAddress, ReceiptConnection)
 	AddSentPacket(p Packet, src, next NodeAddress)
+	SendReceipt(PacketReceipt)
 }
 
 type packetRecord struct {
@@ -27,10 +28,11 @@ type receiptImpl struct {
 	packets     map[PacketHash]packetRecord
 	l           *sync.Mutex
 	a           ReceiptAction
+	id          NodeAddress
 }
 
-func newReceiptImpl(a ReceiptAction) ReceiptHandler {
-	return &receiptImpl{make(map[NodeAddress]ReceiptConnection), make(map[PacketHash]packetRecord), &sync.Mutex{}, a}
+func newReceiptImpl(id NodeAddress, a ReceiptAction) ReceiptHandler {
+	return &receiptImpl{make(map[NodeAddress]ReceiptConnection), make(map[PacketHash]packetRecord), &sync.Mutex{}, a, id}
 }
 
 func (r *receiptImpl) AddConnection(id NodeAddress, c ReceiptConnection) {
@@ -39,32 +41,7 @@ func (r *receiptImpl) AddConnection(id NodeAddress, c ReceiptConnection) {
 	r.l.Unlock()
 	go func() {
 		for receipt := range c.PacketReceipts() {
-			if receipt.Verify() != nil {
-				log.Printf("Error verifying receipt: %q", receipt.Verify())
-				continue
-			}
-			dest := make(map[NodeAddress]bool)
-			r.l.Lock()
-			for _, hash := range receipt.ListPackets() {
-				record, ok := r.packets[hash]
-				if !ok {
-					log.Printf("No record found %q", hash)
-					continue
-				}
-				if record.destination != receipt.Source() {
-					log.Printf("Invalid source %q != %q", record.src, receipt.Source())
-					continue
-				}
-				if record.next != id {
-					log.Printf("Received packet receipt from wrong host? %q", id)
-				}
-				dest[record.src] = true
-				r.a.Receipt(hash)
-			}
-			for addr, _ := range dest {
-				r.connections[addr].SendReceipt(receipt)
-			}
-			r.l.Unlock()
+			r.sendReceipt(id, receipt)
 		}
 	}()
 }
@@ -72,5 +49,38 @@ func (r *receiptImpl) AddConnection(id NodeAddress, c ReceiptConnection) {
 func (r *receiptImpl) AddSentPacket(p Packet, src, next NodeAddress) {
 	r.l.Lock()
 	defer r.l.Unlock()
-	r.packets[p.Hash()] = packetRecord{p.Destination(), next, src, p.Hash()}
+	r.packets[p.Hash()] = packetRecord{p.Destination(), src, next, p.Hash()}
+}
+
+func (r *receiptImpl) SendReceipt(receipt PacketReceipt) {
+	r.sendReceipt(r.id, receipt)
+}
+
+func (r *receiptImpl) sendReceipt(id NodeAddress, receipt PacketReceipt) {
+	if receipt.Verify() != nil {
+		log.Printf("Error verifying receipt: %q", receipt.Verify())
+		return
+	}
+	dest := make(map[NodeAddress]bool)
+	r.l.Lock()
+	defer r.l.Unlock()
+	for _, hash := range receipt.ListPackets() {
+		record, ok := r.packets[hash]
+		if !ok {
+			log.Printf("No record found %q", hash)
+			continue
+		}
+		if record.destination != receipt.Source() {
+			log.Printf("Invalid source %q != %q", record.src, receipt.Source())
+			continue
+		}
+		if record.next != id {
+			log.Printf("Received packet receipt from wrong host? %q != %q", id, record.next)
+		}
+		dest[record.src] = true
+		r.a.Receipt(hash)
+	}
+	for addr, _ := range dest {
+		r.connections[addr].SendReceipt(receipt)
+	}
 }

--- a/receipt_handler.go
+++ b/receipt_handler.go
@@ -78,9 +78,12 @@ func (r *receiptImpl) sendReceipt(id NodeAddress, receipt PacketReceipt) {
 			log.Printf("Received packet receipt from wrong host? %q != %q", id, record.next)
 		}
 		dest[record.src] = true
+		log.Printf("%q: Notifying action", r.id)
 		r.a.Receipt(hash)
 	}
 	for addr, _ := range dest {
-		r.connections[addr].SendReceipt(receipt)
+		if addr != r.id {
+			r.connections[addr].SendReceipt(receipt)
+		}
 	}
 }

--- a/receipt_handler_test.go
+++ b/receipt_handler_test.go
@@ -1,6 +1,7 @@
 package node
 
 import (
+	"log"
 	"testing"
 )
 
@@ -55,8 +56,10 @@ func TestReceiptHandler(t *testing.T) {
 	ri1.AddSentPacket(p, a1, a2)
 	ri2.AddSentPacket(p, a1, a2)
 
-	ri2.SendReceipt(pr{"2", a2})
+	go ri2.SendReceipt(pr{"2", a2})
 
-	<-ra1
 	<-ra2
+	log.Print("notified2")
+	<-ra1
+	log.Print("notified1")
 }

--- a/receipt_handler_test.go
+++ b/receipt_handler_test.go
@@ -1,0 +1,20 @@
+package node
+
+type testReceiptConnection struct {
+	in  chan PacketReceipt
+	out chan PacketReceipt
+}
+
+func (c testReceiptConnection) SendReceipt(r PacketReceipt) error {
+	c.out <- r
+	return nil
+}
+func (c testReceiptConnection) PacketReceipts() <-chan PacketReceipt {
+	return c.in
+}
+
+func makePairedReceiptConnections() (ReceiptConnection, ReceiptConnection) {
+	one := make(chan PacketReceipt)
+	two := make(chan PacketReceipt)
+	return testReceiptConnection{one, two}, testReceiptConnection{two, one}
+}

--- a/receipt_handler_test.go
+++ b/receipt_handler_test.go
@@ -1,5 +1,9 @@
 package node
 
+import (
+	"testing"
+)
+
 type testReceiptConnection struct {
 	in  chan PacketReceipt
 	out chan PacketReceipt
@@ -17,4 +21,42 @@ func makePairedReceiptConnections() (ReceiptConnection, ReceiptConnection) {
 	one := make(chan PacketReceipt)
 	two := make(chan PacketReceipt)
 	return testReceiptConnection{one, two}, testReceiptConnection{two, one}
+}
+
+type ra chan PacketHash
+
+func (r ra) Receipt(h PacketHash) {
+	r <- h
+}
+
+type pr struct {
+	hash string
+	src  NodeAddress
+}
+
+func (p pr) ListPackets() []PacketHash { return []PacketHash{PacketHash(p.hash)} }
+func (p pr) Source() NodeAddress       { return p.src }
+func (p pr) Verify() error             { return nil }
+
+func TestReceiptHandler(t *testing.T) {
+	a1 := NodeAddress("1")
+	a2 := NodeAddress("2")
+
+	c1, c2 := makePairedReceiptConnections()
+	ra1 := ra(make(chan PacketHash))
+	ra2 := ra(make(chan PacketHash))
+	ri1 := newReceiptImpl(a1, ra1)
+	ri1.AddConnection(a2, c1)
+	ri2 := newReceiptImpl(a2, ra2)
+	ri2.AddConnection(a1, c2)
+
+	p := testPacket("2")
+
+	ri1.AddSentPacket(p, a1, a2)
+	ri2.AddSentPacket(p, a1, a2)
+
+	ri2.SendReceipt(pr{"2", a2})
+
+	<-ra1
+	<-ra2
 }

--- a/router.go
+++ b/router.go
@@ -21,8 +21,12 @@ type routerImpl struct {
 	payments    ReceiptHandler
 }
 
+type NullAction struct{}
+
+func (n NullAction) Receipt(PacketHash) {}
+
 func newRouterImpl(id NodeAddress) Router {
-	return &routerImpl{id, make(chan Packet), newMapImpl(id), make(map[NodeAddress]Connection)}
+	return &routerImpl{id, make(chan Packet), newMapImpl(id), make(map[NodeAddress]Connection), newReceiptImpl(NullAction{})}
 }
 
 func (r *routerImpl) GetAddress() PublicKey {

--- a/router.go
+++ b/router.go
@@ -26,7 +26,7 @@ type NullAction struct{}
 func (n NullAction) Receipt(PacketHash) {}
 
 func newRouterImpl(id NodeAddress) Router {
-	return &routerImpl{id, make(chan Packet), newMapImpl(id), make(map[NodeAddress]Connection), newReceiptImpl(NullAction{})}
+	return &routerImpl{id, make(chan Packet), newMapImpl(id), make(map[NodeAddress]Connection), newReceiptImpl(id, NullAction{})}
 }
 
 func (r *routerImpl) GetAddress() PublicKey {

--- a/router.go
+++ b/router.go
@@ -18,6 +18,7 @@ type routerImpl struct {
 	reachability MapHandler
 	// A map of public key hashes to connections
 	connections map[NodeAddress]Connection
+	payments    ReceiptHandler
 }
 
 func newRouterImpl(id NodeAddress) Router {

--- a/router_test.go
+++ b/router_test.go
@@ -28,6 +28,7 @@ func makePairedDataConnections() (DataConnection, DataConnection) {
 type testConnection struct {
 	DataConnection
 	MapConnection
+	ReceiptConnection
 	k PublicKey
 }
 
@@ -37,12 +38,14 @@ func (t testConnection) Key() PublicKey { return t.k }
 func makePairedConnections(k1, k2 PublicKey) (Connection, Connection) {
 	d1, d2 := makePairedDataConnections()
 	m1, m2 := makePairedMapConnections()
-	return testConnection{d1, m1, k1}, testConnection{d2, m2, k2}
+	r1, r2 := makePairedReceiptConnections()
+	return testConnection{d1, m1, r1, k1}, testConnection{d2, m2, r2, k2}
 }
 
 type testPacket NodeAddress
 
 func (p testPacket) Destination() NodeAddress { return NodeAddress(p) }
+func (p testPacket) Hash() PacketHash         { return PacketHash(p) }
 
 func LinkRouters(a, b Router) {
 	c1, c2 := makePairedConnections(a.GetAddress(), b.GetAddress())


### PR DESCRIPTION
This PR adds support packet receipts, which indicate that a packet has been received successfully. The only layer after this should be the actual economy, then I need to start writing wire formats and delving into bitcoins.
