### PR TITLE
Switch the bitcoin payment system to match the rpcwallet interface.

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -32,8 +32,8 @@ type ReceiptConnection interface {
 	PacketReceipts() <-chan PacketReceipt
 }
 type PaymentConnection interface {
-	SendPayment(Payment) error
-	Payments() <-chan Payment
+	SendPayment(PaymentHash) error
+	Payments() <-chan PaymentHash
 }
 
 // While the two connections use different messages, a working ControlConnection has both interfaces

--- a/ledger.go
+++ b/ledger.go
@@ -1,0 +1,124 @@
+package node
+
+import (
+	"log"
+	"sync"
+	"time"
+)
+
+// This keeps track of our outstanding owed payments and provides an interface
+// to send payments. It does not create payments on its own.
+type Ledger interface {
+	RecordPayment(Payment)
+	// There are really only a few interesting pieces of data you will want to
+	// know about. How much we should pay someone, and how much debt + how long
+	// it has been since someone paid us (aka stop relaying to them if they haven't
+	// paid recently enough or the outstanding balance is too high).
+	IncomingDebt(NodeAddress) (int64, time.Time)
+	OutgoingDebt(NodeAddress) (int64, time.Time)
+}
+
+// Debt is recorded as amount + time. The assumption is that debt is payed
+// oldest first.
+type debt struct {
+	time   time.Time
+	amount int64
+}
+
+func payDebt(debts []debt, amount int64) []debt {
+	for _, d := range debts {
+		if d.amount < amount {
+			// not needed since removing
+			amount -= d.amount
+			d.amount = 0
+			debts = debts[1:]
+			continue
+		}
+		d.amount -= amount
+		amount = 0
+		debts[0] = d
+		break
+	}
+	if amount != 0 {
+		// Overpayment?
+		log.Print("Overpayment?: ", amount)
+	}
+	return debts
+}
+
+func sumDebt(debts []debt) (int64, time.Time) {
+	var s time.Time
+	a := int64(0)
+	if len(debts) > 0 {
+		s = debts[0].time
+	}
+	for _, i := range debts {
+		a += i.amount
+	}
+	return a, s
+}
+
+type ledger struct {
+	// debt that other people will pay us
+	incoming_debt map[NodeAddress][]debt
+	// debt that we will pay other people
+	outgoing_debt map[NodeAddress][]debt
+	packets       map[PacketHash]RoutingDecision
+	l             *sync.Mutex
+	id            NodeAddress
+}
+
+func newLedger(id NodeAddress, c <-chan PacketHash, d <-chan RoutingDecision) Ledger {
+	p := &ledger{
+		make(map[NodeAddress][]debt),
+		make(map[NodeAddress][]debt),
+		make(map[PacketHash]RoutingDecision),
+		&sync.Mutex{},
+		id}
+	go p.handleReceipt(c)
+	go p.sentPackets(d)
+	return p
+}
+
+func (p *ledger) IncomingDebt(n NodeAddress) (int64, time.Time) {
+	p.l.Lock()
+	defer p.l.Unlock()
+	return sumDebt(p.incoming_debt[n])
+}
+
+func (p *ledger) OutgoingDebt(n NodeAddress) (int64, time.Time) {
+	p.l.Lock()
+	defer p.l.Unlock()
+	return sumDebt(p.outgoing_debt[n])
+}
+
+func (p *ledger) handleReceipt(c <-chan PacketHash) {
+	for h := range c {
+		p.l.Lock()
+		i, ok := p.packets[h]
+		if !ok {
+			log.Printf("unrecognized hash")
+			p.l.Unlock()
+			continue
+		}
+		d := debt{time.Now(), i.amount}
+		p.incoming_debt[i.source] = append(p.incoming_debt[i.source], d)
+		p.outgoing_debt[i.nexthop] = append(p.outgoing_debt[i.nexthop], d)
+		p.l.Unlock()
+	}
+}
+
+func (p *ledger) sentPackets(c <-chan RoutingDecision) {
+	for d := range c {
+		p.l.Lock()
+		p.packets[d.hash] = d
+		p.l.Unlock()
+	}
+}
+
+func (p *ledger) RecordPayment(y Payment) {
+	p.l.Lock()
+	defer p.l.Unlock()
+	p.incoming_debt[y.Source] = payDebt(p.incoming_debt[y.Source], y.Amount)
+	p.outgoing_debt[y.Destination] = payDebt(p.outgoing_debt[y.Destination], y.Amount)
+}

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -1,0 +1,87 @@
+package node
+
+import (
+	"testing"
+	"time"
+)
+
+func WaitForIncomingDebt(t *testing.T, l Ledger, a NodeAddress, o int64) {
+	timeout := time.After(time.Second)
+	tick := time.Tick(time.Millisecond)
+	d := int64(0)
+	for {
+		select {
+		case <-timeout:
+			t.Errorf("Expected debt from %s to be %d != %d", a, o, d)
+			return
+		case <-tick:
+			d, _ = l.IncomingDebt(a)
+			if d == o {
+				return
+			}
+		}
+	}
+}
+
+func WaitForOutgoingDebt(t *testing.T, l Ledger, a NodeAddress, o int64) {
+	timeout := time.After(time.Second)
+	tick := time.Tick(time.Millisecond)
+	d := int64(0)
+	for {
+		select {
+		case <-timeout:
+			t.Errorf("Expected debt from %s to be %d != %d", a, o, d)
+			return
+		case <-tick:
+			d, _ = l.OutgoingDebt(a)
+			if d == o {
+				return
+			}
+		}
+	}
+}
+
+func TestLedger(t *testing.T) {
+	delivered := make(chan PacketHash)
+	a1, a2, a3 := NodeAddress("1"), NodeAddress("2"), NodeAddress("3")
+
+	routed := make(chan RoutingDecision)
+
+	ledger := newLedger(a1, delivered, routed)
+
+	t1 := testPacket(a2)
+	t2 := testPacket(a3)
+	routed <- NewRoutingDecision(t1, a1, a2)
+	routed <- NewRoutingDecision(t2, a1, a2)
+
+	owed := int64(0)
+	WaitForIncomingDebt(t, ledger, a1, owed)
+	WaitForOutgoingDebt(t, ledger, a2, owed)
+
+	delivered <- t1.Hash()
+	owed = t1.Amount()
+
+	WaitForIncomingDebt(t, ledger, a1, owed)
+	WaitForOutgoingDebt(t, ledger, a2, owed)
+
+	delivered <- t2.Hash()
+	owed += t2.Amount()
+
+	WaitForIncomingDebt(t, ledger, a1, owed)
+	WaitForOutgoingDebt(t, ledger, a2, owed)
+
+	payment := Payment{a1, a2, 4}
+
+	ledger.RecordPayment(payment)
+	owed -= 4
+
+	WaitForIncomingDebt(t, ledger, a1, owed)
+	WaitForOutgoingDebt(t, ledger, a2, owed)
+
+	payment = Payment{a1, a2, owed}
+	ledger.RecordPayment(payment)
+	owed -= owed
+
+	WaitForIncomingDebt(t, ledger, a1, owed)
+	WaitForOutgoingDebt(t, ledger, a2, owed)
+}

--- a/node.go
+++ b/node.go
@@ -74,7 +74,8 @@ func (n *node) sendPayments() {
 					log.Printf("Failed to make a payment to %d : %v", c, err)
 					break
 				}
-				n.Router.SendPayment(p)
+				n.Router.RecordPayment(Payment{n.id.PublicKey().Hash(), c, owed})
+				n.Router.SendPayment(c, p)
 			}
 		}
 		n.l.Unlock()

--- a/payment.go
+++ b/payment.go
@@ -8,8 +8,8 @@ import (
 // to send payments. It does not create payments on its own.
 type PaymentHandler interface {
 	AddConnection(NodeAddress, PaymentConnection)
-	SendPayment(NodeAddress, PaymentHash) error
-	Payments() <-chan PaymentHash
+	SendPaymentHash(NodeAddress, PaymentHash) error
+	PaymentHashes() <-chan PaymentHash
 }
 
 type payment struct {
@@ -28,7 +28,7 @@ func newPayment(id NodeAddress) PaymentHandler {
 	return p
 }
 
-func (p *payment) Payments() <-chan PaymentHash {
+func (p *payment) PaymentHashes() <-chan PaymentHash {
 	return p.c
 }
 
@@ -45,7 +45,7 @@ func (p *payment) handleConnection(c PaymentConnection) {
 	}
 }
 
-func (p *payment) SendPayment(id NodeAddress, y PaymentHash) error {
+func (p *payment) SendPaymentHash(id NodeAddress, y PaymentHash) error {
 	p.l.Lock()
 	defer p.l.Unlock()
 	return p.connections[id].SendPayment(y)

--- a/payment.go
+++ b/payment.go
@@ -1,86 +1,35 @@
 package node
 
 import (
-	"log"
 	"sync"
-	"time"
 )
 
 // This keeps track of our outstanding owed payments and provides an interface
 // to send payments. It does not create payments on its own.
 type PaymentHandler interface {
 	AddConnection(NodeAddress, PaymentConnection)
-	SendPayment(Payment)
-	// There are really only a few interesting pieces of data you will want to
-	// know about. How much we should pay someone, and how much debt + how long
-	// it has been since someone paid us (aka stop relaying to them if they haven't
-	// paid recently enough or the outstanding balance is too high).
-	IncomingDebt(NodeAddress) (int64, time.Time)
-	OutgoingDebt(NodeAddress) (int64, time.Time)
-}
-
-// Debt is recorded as amount + time. The assumption is that debt is payed
-// oldest first.
-type debt struct {
-	time   time.Time
-	amount int64
-}
-
-func payDebt(debts []debt, amount int64) []debt {
-	for _, d := range debts {
-		if d.amount < amount {
-			// not needed since removing
-			amount -= d.amount
-			d.amount = 0
-			debts = debts[1:]
-			continue
-		}
-		d.amount -= amount
-		amount = 0
-		debts[0] = d
-		break
-	}
-	if amount != 0 {
-		// Overpayment?
-		log.Print("Overpayment?: ", amount)
-	}
-	return debts
-}
-
-func sumDebt(debts []debt) (int64, time.Time) {
-	var s time.Time
-	a := int64(0)
-	if len(debts) > 0 {
-		s = debts[0].time
-	}
-	for _, i := range debts {
-		a += i.amount
-	}
-	return a, s
+	SendPayment(NodeAddress, PaymentHash) error
+	Payments() <-chan PaymentHash
 }
 
 type payment struct {
-	// debt that other people will pay us
-	incoming_debt map[NodeAddress][]debt
-	// debt that we will pay other people
-	outgoing_debt map[NodeAddress][]debt
-	connections   map[NodeAddress]PaymentConnection
-	packets       map[PacketHash]RoutingDecision
-	l             *sync.Mutex
-	id            NodeAddress
+	connections map[NodeAddress]PaymentConnection
+	c           chan PaymentHash
+	l           *sync.Mutex
+	id          NodeAddress
 }
 
-func newPayment(id NodeAddress, c <-chan PacketHash, d <-chan RoutingDecision) PaymentHandler {
+func newPayment(id NodeAddress) PaymentHandler {
 	p := &payment{
-		make(map[NodeAddress][]debt),
-		make(map[NodeAddress][]debt),
 		make(map[NodeAddress]PaymentConnection),
-		make(map[PacketHash]RoutingDecision),
+		make(chan PaymentHash),
 		&sync.Mutex{},
 		id}
-	go p.handleReceipt(c)
-	go p.sentPackets(d)
 	return p
+}
+
+func (p *payment) Payments() <-chan PaymentHash {
+	return p.c
 }
 
 func (p *payment) AddConnection(id NodeAddress, c PaymentConnection) {
@@ -91,55 +40,13 @@ func (p *payment) AddConnection(id NodeAddress, c PaymentConnection) {
 }
 
 func (p *payment) handleConnection(c PaymentConnection) {
-	for pay := range c.Payments() {
-		if pay.Verify() != nil {
-			log.Printf("Error verifying payment: %s", pay.Verify())
-			continue
-		}
-		p.l.Lock()
-		p.incoming_debt[pay.Source()] = payDebt(p.incoming_debt[pay.Source()], pay.Amount())
-		p.l.Unlock()
+	for hash := range c.Payments() {
+		p.c <- hash
 	}
 }
 
-func (p *payment) IncomingDebt(n NodeAddress) (int64, time.Time) {
+func (p *payment) SendPayment(id NodeAddress, y PaymentHash) error {
 	p.l.Lock()
 	defer p.l.Unlock()
-	return sumDebt(p.incoming_debt[n])
-}
-
-func (p *payment) OutgoingDebt(n NodeAddress) (int64, time.Time) {
-	p.l.Lock()
-	defer p.l.Unlock()
-	return sumDebt(p.outgoing_debt[n])
-}
-
-func (p *payment) handleReceipt(c <-chan PacketHash) {
-	for h := range c {
-		p.l.Lock()
-		i, ok := p.packets[h]
-		if !ok {
-			log.Printf("unrecognized hash")
-			return
-		}
-		d := debt{time.Now(), i.amount}
-		p.incoming_debt[i.source] = append(p.incoming_debt[i.source], d)
-		p.outgoing_debt[i.nexthop] = append(p.outgoing_debt[i.nexthop], d)
-		p.l.Unlock()
-	}
-}
-
-func (p *payment) sentPackets(c <-chan RoutingDecision) {
-	for d := range c {
-		p.l.Lock()
-		p.packets[d.hash] = d
-		p.l.Unlock()
-	}
-}
-
-func (p *payment) SendPayment(y Payment) {
-	p.l.Lock()
-	defer p.l.Unlock()
-	p.connections[y.Destination()].SendPayment(y)
-	p.outgoing_debt[y.Destination()] = payDebt(p.outgoing_debt[y.Destination()], y.Amount())
+	return p.connections[id].SendPayment(y)
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -2,99 +2,39 @@ package node
 
 import (
 	"testing"
-	"time"
 )
 
 type testPaymentConnection struct {
-	in  chan Payment
-	out chan Payment
+	in  chan PaymentHash
+	out chan PaymentHash
 }
 
-func (c testPaymentConnection) SendPayment(p Payment) error {
+func (c testPaymentConnection) SendPayment(p PaymentHash) error {
 	c.out <- p
 	return nil
 }
-func (c testPaymentConnection) Payments() <-chan Payment {
+func (c testPaymentConnection) Payments() <-chan PaymentHash {
 	return c.in
 }
 
 func makePairedPaymentConnections() (PaymentConnection, PaymentConnection) {
-	one := make(chan Payment)
-	two := make(chan Payment)
+	one := make(chan PaymentHash)
+	two := make(chan PaymentHash)
 	return testPaymentConnection{one, two}, testPaymentConnection{two, one}
 }
 
-func WaitForIncomingDebt(t *testing.T, p PaymentHandler, a NodeAddress, m int64) {
-	timeout := time.After(time.Second)
-	tick := time.Tick(time.Millisecond * 5)
-	for {
-		select {
-		case _ = <-timeout:
-			t.Fatalf("Timeout witing for IncomingDebt(%v) from %v in %v", m, a, p)
-			return
-		case _ = <-tick:
-			if d, _ := p.IncomingDebt(a); d == m {
-				return
-			}
-		}
-	}
-}
-
-func WaitForOutgoingDebt(t *testing.T, p PaymentHandler, a NodeAddress, m int64) {
-	timeout := time.After(time.Second)
-	tick := time.Tick(time.Millisecond * 5)
-	for {
-		select {
-		case _ = <-timeout:
-			t.Fatalf("Timeout witing for OutgoingDebt(%v) from %v in %v", m, a, p)
-			return
-		case _ = <-tick:
-			if d, _ := p.OutgoingDebt(a); d == m {
-				return
-			}
-		}
-	}
-}
-
 func TestPaymentHandler(t *testing.T) {
-	h1, h2 := make(chan PacketHash), make(chan PacketHash)
 	c1, c2 := makePairedPaymentConnections()
 	a1, a2 := NodeAddress("1"), NodeAddress("2")
-	i1, i2 := make(chan RoutingDecision), make(chan RoutingDecision)
-	p1, p2 := newPayment(a1, h1, i1), newPayment(a2, h2, i2)
+	p1, p2 := newPayment(a1), newPayment(a2)
 	p1.AddConnection(a2, c1)
 	p2.AddConnection(a1, c2)
 
-	t1 := testPacket(a2)
-	t2 := testPacket(NodeAddress("3"))
-	i1 <- NewRoutingDecision(t1, a1, a2)
-	WaitForIncomingDebt(t, p1, a1, 0)
-	WaitForOutgoingDebt(t, p1, a2, 0)
-	h1 <- t1.Hash()
-	owed := t1.Amount()
-	WaitForIncomingDebt(t, p1, a1, owed)
-	WaitForOutgoingDebt(t, p1, a2, owed)
+	go p1.SendPayment(a2, PaymentHash("hash"))
 
-	i2 <- NewRoutingDecision(t1, a1, a2)
-	h2 <- t1.Hash()
-	WaitForIncomingDebt(t, p2, a1, owed)
+	h := <-p2.Payments()
+	if string(h) != "hash" {
+		t.Fatalf("Expected %s == hash", string(h))
+	}
 
-	i1 <- NewRoutingDecision(t2, a1, a2)
-	h1 <- t2.Hash()
-	owed += t2.Amount()
-	WaitForIncomingDebt(t, p1, a1, owed)
-	WaitForOutgoingDebt(t, p1, a2, owed)
-	i2 <- NewRoutingDecision(t2, a1, a2)
-	h2 <- t2.Hash()
-	WaitForIncomingDebt(t, p2, a1, owed)
-
-	payment := testPayment{a1, a2, 4}
-	p1.SendPayment(payment)
-	owed -= 4
-	WaitForIncomingDebt(t, p2, a1, owed)
-	WaitForOutgoingDebt(t, p1, a2, owed)
-	payment = testPayment{a1, a2, owed}
-	p1.SendPayment(payment)
-	WaitForIncomingDebt(t, p2, a1, 0)
-	WaitForOutgoingDebt(t, p1, a2, 0)
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -30,9 +30,9 @@ func TestPaymentHandler(t *testing.T) {
 	p1.AddConnection(a2, c1)
 	p2.AddConnection(a1, c2)
 
-	go p1.SendPayment(a2, PaymentHash("hash"))
+	go p1.SendPaymentHash(a2, PaymentHash("hash"))
 
-	h := <-p2.Payments()
+	h := <-p2.PaymentHashes()
 	if string(h) != "hash" {
 		t.Fatalf("Expected %s == hash", string(h))
 	}

--- a/router.go
+++ b/router.go
@@ -13,7 +13,8 @@ type Router interface {
 	DataConnection
 	GetAddress() PublicKey
 	SendReceipt(PacketReceipt)
-	SendPayment(Payment)
+	SendPayment(NodeAddress, PaymentHash) error
+	RecordPayment(Payment)
 	Connections() []NodeAddress
 	IncomingDebt(NodeAddress) (int64, time.Time)
 	OutgoingDebt(NodeAddress) (int64, time.Time)
@@ -28,6 +29,7 @@ type router struct {
 	RoutingHandler
 	ReceiptHandler
 	PaymentHandler
+	Ledger
 }
 
 func newRouter(pk PublicKey) Router {
@@ -35,14 +37,16 @@ func newRouter(pk PublicKey) Router {
 	routing := newRouting(pk, reach)
 	c1, c2 := SplitChannel(routing.Routes())
 	receipt := newReceipt(pk.Hash(), c1)
-	payment := newPayment(pk.Hash(), receipt.PacketHashes(), c2)
+	payment := newPayment(pk.Hash())
+	ledger := newLedger(pk.Hash(), receipt.PacketHashes(), c2)
 	return &router{
 		pk,
 		make(map[NodeAddress]Connection),
 		reach,
 		routing,
 		receipt,
-		payment}
+		payment,
+		ledger}
 }
 
 func (r *router) GetAddress() PublicKey {

--- a/router.go
+++ b/router.go
@@ -13,7 +13,8 @@ type Router interface {
 	DataConnection
 	GetAddress() PublicKey
 	SendReceipt(PacketReceipt)
-	SendPayment(NodeAddress, PaymentHash) error
+	SendPaymentHash(NodeAddress, PaymentHash) error
+	PaymentHashes() <-chan PaymentHash
 	RecordPayment(Payment)
 	Connections() []NodeAddress
 	IncomingDebt(NodeAddress) (int64, time.Time)


### PR DESCRIPTION
This is mostly a refactor so that we're no longer sending bitcoin payments over the wire thus allowing us to use bitcoins with less insane amounts of work required.
