### PR TITLE
Make use be able to shutdown cleanly

### DIFF
--- a/channels.go
+++ b/channels.go
@@ -7,6 +7,8 @@ func splitChannel(c <-chan routingDecision) (<-chan routingDecision, <-chan rout
 			c1 <- d
 			c2 <- d
 		}
+		close(c1)
+		close(c2)
 	}()
 	return c1, c2
 }

--- a/node.go
+++ b/node.go
@@ -31,6 +31,7 @@ func NewNode(pk PrivateKey, receipt_ticker <-chan time.Time, payment_ticker <-ch
 		fakeMoney{pk.PublicKey().Hash()},
 	}
 	go n.receivePackets()
+	go n.receivePayments()
 	go n.sendReceipts()
 	go n.sendPayments()
 	return n
@@ -93,4 +94,8 @@ func (n *Node) SendPacket(p Packet) error {
 
 func (n *Node) Packets() <-chan Packet {
 	return n.outgoing
+}
+
+func (n *Node) Close() error {
+	return n.router.Close()
 }

--- a/node_test.go
+++ b/node_test.go
@@ -17,6 +17,8 @@ func TestNode(t *testing.T) {
 	c := make(chan time.Time)
 	n1 := NewNode(sk1, time.Tick(100*time.Millisecond), c)
 	n2 := NewNode(sk2, time.Tick(100*time.Millisecond), time.Tick(100*time.Millisecond))
+	defer n1.Close()
+	defer n2.Close()
 	link(n1, n2)
 
 	p2 := testPacket(sk2.PublicKey().Hash())

--- a/payment.go
+++ b/payment.go
@@ -44,3 +44,8 @@ func (p *paymentHandler) SendPaymentHash(id NodeAddress, y PaymentHash) error {
 	defer p.l.Unlock()
 	return p.connections[id].SendPayment(y)
 }
+
+func (p *paymentHandler) Close() error {
+	close(p.c)
+	return nil
+}

--- a/payment_test.go
+++ b/payment_test.go
@@ -28,13 +28,13 @@ func makePairedPaymentConnections() (testPaymentConnection, testPaymentConnectio
 }
 
 func TestPaymentHandler(t *testing.T) {
-	c1, c2 := makePairedPaymentConnections()
-	defer c1.Close()
-	defer c2.Close()
 	a1, a2 := NodeAddress("1"), NodeAddress("2")
 	p1, p2 := newPayment(a1), newPayment(a2)
 	defer p1.Close()
 	defer p2.Close()
+	c1, c2 := makePairedPaymentConnections()
+	defer c1.Close()
+	defer c2.Close()
 	p1.AddConnection(a2, c1)
 	p2.AddConnection(a1, c2)
 
@@ -44,5 +44,4 @@ func TestPaymentHandler(t *testing.T) {
 	if string(h) != "hash" {
 		t.Fatalf("Expected %s == hash", string(h))
 	}
-
 }

--- a/payment_test.go
+++ b/payment_test.go
@@ -16,8 +16,12 @@ func (c testPaymentConnection) SendPayment(p PaymentHash) error {
 func (c testPaymentConnection) Payments() <-chan PaymentHash {
 	return c.in
 }
+func (c testPaymentConnection) Close() error {
+	close(c.in)
+	return nil
+}
 
-func makePairedPaymentConnections() (PaymentConnection, PaymentConnection) {
+func makePairedPaymentConnections() (testPaymentConnection, testPaymentConnection) {
 	one := make(chan PaymentHash)
 	two := make(chan PaymentHash)
 	return testPaymentConnection{one, two}, testPaymentConnection{two, one}
@@ -25,8 +29,12 @@ func makePairedPaymentConnections() (PaymentConnection, PaymentConnection) {
 
 func TestPaymentHandler(t *testing.T) {
 	c1, c2 := makePairedPaymentConnections()
+	defer c1.Close()
+	defer c2.Close()
 	a1, a2 := NodeAddress("1"), NodeAddress("2")
 	p1, p2 := newPayment(a1), newPayment(a2)
+	defer p1.Close()
+	defer p2.Close()
 	p1.AddConnection(a2, c1)
 	p2.AddConnection(a1, c2)
 

--- a/reachability_test.go
+++ b/reachability_test.go
@@ -17,8 +17,12 @@ func (c testMapConnection) SendMap(m BloomReachabilityMap) error {
 func (c testMapConnection) ReachabilityMaps() <-chan BloomReachabilityMap {
 	return c.in
 }
+func (c testMapConnection) Close() error {
+	close(c.in)
+	return nil
+}
 
-func makePairedMapConnections() (MapConnection, MapConnection) {
+func makePairedMapConnections() (testMapConnection, testMapConnection) {
 	one := make(chan BloomReachabilityMap)
 	two := make(chan BloomReachabilityMap)
 	return testMapConnection{one, two}, testMapConnection{two, one}

--- a/receipt.go
+++ b/receipt.go
@@ -79,3 +79,8 @@ func (r *receiptHandler) sendReceipt(id NodeAddress, receipt PacketReceipt) {
 		}
 	}
 }
+
+func (r *receiptHandler) Close() error {
+	close(r.outgoing)
+	return nil
+}

--- a/router.go
+++ b/router.go
@@ -60,3 +60,13 @@ func (r *router) AddConnection(c Connection) {
 	r.receiptHandler.AddConnection(id, c)
 	r.paymentHandler.AddConnection(id, c)
 }
+
+func (r *router) Close() error {
+	for _, v := range r.connections {
+		v.Close()
+	}
+	r.routingHandler.Close()
+	r.receiptHandler.Close()
+	r.paymentHandler.Close()
+	return nil
+}

--- a/routing.go
+++ b/routing.go
@@ -60,14 +60,14 @@ func (r *routingHandler) SendPacket(p Packet) error {
 func (r *routingHandler) sendPacket(p Packet, src NodeAddress) error {
 	if p.Destination() == r.pk.Hash() {
 		r.incoming <- p
-		go r.notifyDecision(p, src, r.pk.Hash())
+		r.notifyDecision(p, src, r.pk.Hash())
 		return nil
 	}
 	next, err := r.reachability.FindNextHop(p.Destination())
 	if err != nil {
 		return err
 	}
-	go r.notifyDecision(p, src, next)
+	r.notifyDecision(p, src, next)
 	return r.connections[next].SendPacket(p)
 }
 
@@ -81,4 +81,10 @@ func (r *routingHandler) Routes() <-chan routingDecision {
 
 func (r *routingHandler) Packets() <-chan Packet {
 	return r.incoming
+}
+
+func (r *routingHandler) Close() error {
+	close(r.incoming)
+	close(r.routes)
+	return nil
 }


### PR DESCRIPTION
This was buggin me when I was trying to debug stack traces, so we now clean up excess go routines.
