### PR TITLE
Fix crash when we get bad ssh packets (?)

### DIFF
--- a/crypto.go
+++ b/crypto.go
@@ -59,6 +59,12 @@ func (e Signature) Key() PublicKey {
 
 func (e Signature) Verify() error {
 	k := ecdsa.PublicKey(e.K)
+	if k.X == nil || k.Y == nil {
+		return errors.New("Invalid Signature")
+	}
+	if e.M == nil || e.S == nil {
+		return errors.New("Invalid Signature")
+	}
 	if !ecdsa.Verify(&k, e.M, e.R, e.S) {
 		return errors.New("Invalid Signature")
 	}

--- a/crypto_test.go
+++ b/crypto_test.go
@@ -22,3 +22,10 @@ func TestCrypto(t *testing.T) {
 		t.Fatalf("Expected %v != %v", s.Signed(), m)
 	}
 }
+
+func TestEmptyVerify(t *testing.T) {
+	var sig Signature
+	if sig.Verify() == nil {
+		t.Fatal("Empty signature should fail to verify")
+	}
+}


### PR DESCRIPTION
It turns out we segfault if we don't initialize a signature. We shouldn't.
