### PR TITLE
Add bitcoin integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,19 @@ language: go
 go:
   - 1.5.1
 
+addons:
+  apt:
+    packages:
+      - bitcoin
+
+before_script:
+  - mkdir ${GOPATH}/src/github.com/freewil
+  - mkdir ${GOPATH}/src/github.com/freewil/bitcoin-testnet-box
+  - git clone https://github.com/freewil/bitcoin-testnet-box.git ${GOPATH}/src/github.com/freewil/bitcoin-testnet-box
+  - wget https://bitcoin.org/bin/bitcoin-core-0.11.2/bitcoin-0.11.2-linux64.tar.gz -O /tmp/bitcoin.tar.gz
+  - tar -xvf /tmp/bitcoin.tar.gz
+  - export PATH=$PATH:$(pwd)/bitcoin-0.11.2/bin
+
 script:
   - go test -v github.com/AutoRoute/node -race
   - go test -v github.com/AutoRoute/node/integration_tests

--- a/integration_tests/autoroute_binary.go
+++ b/integration_tests/autoroute_binary.go
@@ -21,6 +21,9 @@ type BinaryOptions struct {
 	Connect              []string
 	Autodiscover         bool
 	Autodiscover_devices []string
+	BTCHost              string
+	BTCUser              string
+	BTCPass              string
 }
 
 // Transforms a BinaryOptions into a valid AutoRoute command line.
@@ -38,6 +41,15 @@ func ProduceCommandLine(b BinaryOptions) []string {
 	}
 	if len(b.Autodiscover_devices) > 0 {
 		args = append(args, "--devs="+strings.Join(b.Autodiscover_devices, ","))
+	}
+	if len(b.BTCHost) > 0 {
+		args = append(args, "--btc_host="+b.BTCHost)
+	}
+	if len(b.BTCUser) > 0 {
+		args = append(args, "--btc_user="+b.BTCUser)
+	}
+	if len(b.BTCPass) > 0 {
+		args = append(args, "--btc_pass="+b.BTCPass)
 	}
 	return args
 }

--- a/integration_tests/bitcoin_test.go
+++ b/integration_tests/bitcoin_test.go
@@ -1,0 +1,100 @@
+package integration_tests
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+var test_net_path string = filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "freewil", "bitcoin-testnet-box")
+
+func WaitForGetInfo() error {
+	timeout := time.After(10 * time.Second)
+	for range time.Tick(10 * time.Millisecond) {
+		cmd := exec.Command("make", "getinfo")
+		cmd.Dir = test_net_path
+		out, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		select {
+		case <-timeout:
+			return errors.New(fmt.Sprint(err, string(out)))
+		default:
+		}
+	}
+	panic("unreachable")
+}
+
+func TestBitcoin(t *testing.T) {
+	log.Print("Starting")
+
+	cmd := exec.Command("make", "start")
+	cmd.Dir = test_net_path
+	log.Print("Starting")
+	err := cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		cmd = exec.Command("make", "stop")
+		cmd.Dir = test_net_path
+		log.Print("Stop")
+		err = cmd.Run()
+		if err != nil {
+			log.Print(err)
+		}
+		log.Print("Done")
+		cmd = exec.Command("make", "clean")
+		cmd.Dir = test_net_path
+		log.Print("Cleaning")
+		err = cmd.Run()
+		if err != nil {
+			log.Print(err)
+		}
+		log.Print("Done")
+	}()
+
+	err = WaitForGetInfo()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	listen := NewNodeBinary(BinaryOptions{
+		Listen:  "[::1]:9999",
+		BTCHost: "[::1]:19001",
+		BTCUser: "admin1",
+		BTCPass: "123",
+	})
+	listen.Start()
+	defer listen.KillAndPrint(t)
+	_, err = WaitForID(listen)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	connect := NewNodeBinary(BinaryOptions{
+		Listen:  "[::1]:9998",
+		Connect: []string{"[::1]:9999"},
+		BTCHost: "[::1]:19011",
+		BTCUser: "admin2",
+		BTCPass: "123",
+	})
+	connect.Start()
+	defer connect.KillAndPrint(t)
+	connect_id, err := WaitForID(connect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = WaitForConnection(listen, connect_id)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/integration_tests/bitcoin_test.go
+++ b/integration_tests/bitcoin_test.go
@@ -32,33 +32,26 @@ func WaitForGetInfo() error {
 }
 
 func TestBitcoin(t *testing.T) {
-	log.Print("Starting")
-
 	cmd := exec.Command("make", "start")
 	cmd.Dir = test_net_path
-	log.Print("Starting")
 	err := cmd.Run()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	defer func() {
-		cmd = exec.Command("make", "stop")
+		cmd := exec.Command("make", "stop")
 		cmd.Dir = test_net_path
-		log.Print("Stop")
 		err = cmd.Run()
 		if err != nil {
 			log.Print(err)
 		}
-		log.Print("Done")
 		cmd = exec.Command("make", "clean")
 		cmd.Dir = test_net_path
-		log.Print("Cleaning")
 		err = cmd.Run()
 		if err != nil {
 			log.Print(err)
 		}
-		log.Print("Done")
 	}()
 
 	err = WaitForGetInfo()

--- a/ledger_test.go
+++ b/ledger_test.go
@@ -15,7 +15,7 @@ func WaitForIncomingDebt(t *testing.T, l *ledger, a NodeAddress, o int64) {
 			t.Errorf("Expected incoming debt from %s to be %d != %d", a, o, d)
 			return
 		case <-tick:
-			d, _ = l.IncomingDebt(a)
+			d = l.IncomingDebt(a)
 			if d == o {
 				return
 			}
@@ -33,7 +33,7 @@ func WaitForOutgoingDebt(t *testing.T, l *ledger, a NodeAddress, o int64) {
 			t.Errorf("Expected outgoing debt from %s to be %d != %d", a, o, d)
 			return
 		case <-tick:
-			d, _ = l.OutgoingDebt(a)
+			d = l.OutgoingDebt(a)
 			if d == o {
 				return
 			}

--- a/node.go
+++ b/node.go
@@ -78,7 +78,7 @@ func (n *Node) sendPayments() {
 		case <-n.payment_ticker:
 			n.l.Lock()
 			for _, c := range n.router.Connections() {
-				owed, _ := n.router.OutgoingDebt(c.Key().Hash())
+				owed := n.router.OutgoingDebt(c.Key().Hash())
 				log.Printf("Owe %x %d", c.Key().Hash(), owed)
 				if owed > 0 {
 					log.Printf("Sending payment to %s", c.OtherMetaData().Payment_Address)

--- a/node.go
+++ b/node.go
@@ -114,7 +114,7 @@ func (n *Node) Close() error {
 func (n *Node) GetNewAddress() string {
 	address, c, err := n.m.GetNewAddress()
 	if err != nil {
-		log.Fatal("Failed to get payment address", err)
+		log.Fatal("Failed to get payment address: ", err)
 	}
 	n.router.ledger.AddAddress(address, c)
 	return address


### PR DESCRIPTION
This adds a basic test which makes sure connections can come up when running against a real bitcoin instance.

It also simplifies the histograms stats from ledger.go
