### PR TITLE
Make KillAndPrint wait for the process to exit.

### DIFF
--- a/integration_tests/binary.go
+++ b/integration_tests/binary.go
@@ -33,4 +33,5 @@ func (b WrappedBinary) KillAndPrint(f LogFailer) {
 		f.Logf("\n8<----\n%s8<----\n\n", b.output)
 	}
 	b.Process.Signal(os.Interrupt)
+	b.Cmd.Wait()
 }


### PR DESCRIPTION
This is needed, since loopback2 performs some delicate cleanup
that will jeopardize the functioning of later tests if it is
interrupted.
