### PR TITLE
Skip root tests when not root in order to simplify test execution.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,7 @@ install:
   - wget https://bitcoin.org/bin/bitcoin-core-0.11.2/bitcoin-0.11.2-linux64.tar.gz -O /tmp/bitcoin.tar.gz
   - tar -xvf /tmp/bitcoin.tar.gz
   - export PATH=$PATH:$(pwd)/bitcoin-0.11.2/bin
+  - go get github.com/AutoRoute/loopback2
 
 script:
-  - go test -v github.com/AutoRoute/node/autoroute -race
-  - go test -v github.com/AutoRoute/node -race
-  - go test -v github.com/AutoRoute/node/internal -race
-  - go test -v github.com/AutoRoute/node/integration_tests -race
+  - go test -v github.com/AutoRoute/node/... -race

--- a/integration_tests/root/autodiscovery_test.go
+++ b/integration_tests/root/autodiscovery_test.go
@@ -80,10 +80,13 @@ func SetDevUp(dev string) error {
 
 func TestConnection(t *testing.T) {
 	// set -e
-	WarnRoot(t)
+	err := CheckRoot()
+	if err != nil {
+		t.Skip(err)
+	}
 	// loopback2
 	cmd := integration.NewWrappedBinary(GetLoopBack2Path())
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_tests/root/check_root.go
+++ b/integration_tests/root/check_root.go
@@ -1,19 +1,21 @@
 package root
 
 import (
+	"errors"
+	"fmt"
 	"os/user"
-	"testing"
 )
 
-func WarnRoot(t *testing.T) {
+func CheckRoot() error {
 	user, err := user.Current()
 	if err != nil {
-		t.Log(
+		return errors.New(
 			"Unable to determine user.. These tests require root and may fail.")
 	}
 	if user.Username != "root" {
-		t.Logf(
+		return fmt.Errorf(
 			"Current user is %s which is not root. These tests require root.",
 			user.Username)
 	}
+	return nil
 }

--- a/integration_tests/root/network_sim_test.go
+++ b/integration_tests/root/network_sim_test.go
@@ -27,13 +27,16 @@ type ConnectionType struct {
 }
 
 func TestNetwork(t *testing.T) {
-	WarnRoot(t)
+	err := CheckRoot()
+	if err != nil {
+		t.Skip(err)
+	}
 
 	// config file
 	config := "network_sim_network.json"
 
 	cmd := integration.NewWrappedBinary(GetLoopBack2Path(), "--config="+config)
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/integration_tests/root/ping_test.go
+++ b/integration_tests/root/ping_test.go
@@ -16,6 +16,11 @@ func SetDevAddr(dev string, addr string) error {
 }
 
 func TestPing(t *testing.T) {
+	err := CheckRoot()
+	if err != nil {
+		t.Skip(err)
+	}
+
 	_, key0, err := node.CreateKey("/tmp/keyfile0")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This drops travis back down to 1 command.
