### PR TITLE
Make network_sim_test use its own JSON file.

### DIFF
--- a/integration_tests/root/network_sim_network.json
+++ b/integration_tests/root/network_sim_network.json
@@ -1,0 +1,12 @@
+{
+	"connections": [
+		{
+			"source": "A",
+			"destination": "B"
+		},
+		{
+			"source": "A",
+			"destination": "C"
+		}
+	]
+}

--- a/integration_tests/root/network_sim_test.go
+++ b/integration_tests/root/network_sim_test.go
@@ -10,9 +10,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -32,7 +30,7 @@ func TestNetwork(t *testing.T) {
 	WarnRoot(t)
 
 	// config file
-	config := filepath.Join(os.Getenv("GOPATH"), "src", "github.com", "AutoRoute", "loopback2", "examples", "sample.json")
+	config := "network_sim_network.json"
 
 	cmd := integration.NewWrappedBinary(GetLoopBack2Path(), "--config="+config)
 	err := cmd.Start()


### PR DESCRIPTION
It turns out that the timeouts in network_sim_test weren't really
calibrated for loopback's low-bandwidth simulation, so when we
changed the sample config file to include bandwidth limitations,
that caused problems. Now this test has its own particular JSON
file that works well with it.
