### PR TITLE
Make duplicate connection detection work properly.

### DIFF
--- a/server.go
+++ b/server.go
@@ -22,36 +22,20 @@ type Server struct {
 	listeners map[string]*internal.SSHListener
 	// This contains the addresses of the nodes that we are currently connecting
 	// to, so we don't try to connect to them twice at the same time.
-	currently_connecting map[string]bool
+	currently_connecting map[types.NodeAddress]bool
 	// Mutex to protect accesses to te currently_connecting map.
-	connecting_mutex sync.RWMutex
+	connecting_mutex sync.Mutex
 	listen_address   string
 }
 
 func NewServer(key Key, m types.Money) *Server {
 	n := internal.NewNode(key.k, m, time.Tick(30*time.Second), time.Tick(30*time.Second))
 	return &Server{n, make(map[string]*internal.SSHListener),
-		make(map[string]bool), sync.RWMutex{}, ""}
+		make(map[types.NodeAddress]bool), sync.Mutex{}, ""}
 }
 
 func (s *Server) Connect(addr string) error {
-	// Check that we should be connecting.
-	s.connecting_mutex.RLock()
-	_, addr_present := s.currently_connecting[addr]
-	s.connecting_mutex.RUnlock()
-	if addr_present {
-		return errors.New(fmt.Sprintf("Already connecting to %s.\n", addr))
-	}
-	s.connecting_mutex.Lock()
-	s.currently_connecting[addr] = true
-	s.connecting_mutex.Unlock()
-
 	c, err := net.Dial("tcp6", addr)
-
-	// Now that we've tried connecting, remove it as a pending connection.
-	s.connecting_mutex.Lock()
-	delete(s.currently_connecting, addr)
-	s.connecting_mutex.Unlock()
 
 	if err != nil {
 		return err
@@ -133,7 +117,23 @@ func (s *Server) findNeighbors(dev net.Interface, ll_addr net.IP, port uint16) {
 			log.Print("Warning: Ignoring connection from self.\n")
 			continue
 		}
-		err := s.Connect(fmt.Sprintf("[%s%%%s]:%v", neighbor.LLAddrStr, dev.Name, neighbor.Port))
+
+		// Check that we should be connecting.
+		s.connecting_mutex.Lock()
+		_, addr_present := s.currently_connecting[neighbor.FullNodeAddr]
+		if addr_present {
+			log.Printf("Already connecting to %s.\n", neighbor.FullNodeAddr)
+			continue
+		}
+		s.currently_connecting[neighbor.FullNodeAddr] = true
+
+		err := s.Connect(fmt.Sprintf("[%s%%%s]:%v", neighbor.LLAddrStr, dev.Name,
+			neighbor.Port))
+
+		// Now that we've tried connecting, remove it as a pending connection.
+		delete(s.currently_connecting, neighbor.FullNodeAddr)
+		s.connecting_mutex.Unlock()
+
 		if err != nil {
 			log.Printf("Error connecting: %v", err)
 			continue


### PR DESCRIPTION
It turns out using the LL addresses doesn't work because they're
unique between devices. Now it uses the full node addresses
instead.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/autoroute/node/79)

<!-- Reviewable:end -->
