### PR TITLE
Make it stop sending maps eventually.

### DIFF
--- a/internal/bloom_reachability_map.go
+++ b/internal/bloom_reachability_map.go
@@ -1,13 +1,29 @@
 package internal
 
 import (
+  "encoding/base64"
+  "hash/fnv"
+
 	"github.com/AutoRoute/bloom"
 	"github.com/AutoRoute/node/types"
 )
 
 type BloomReachabilityMap struct {
-	Filters      []*bloom.BloomFilter
-	Conglomerate *bloom.BloomFilter
+	Filters                []*bloom.BloomFilter
+	// Allows us to keep track of filters between nodes.
+	filter_hashes          map[string]bool
+	Conglomerate           *bloom.BloomFilter
+}
+
+// Generates a unique hash for a particular filter.
+// Args:
+//  filter: The filter to hash.
+// Returns:
+//  The FNV hash of the filter.
+func hashFilter(filter *bloom.BloomFilter) string {
+  hasher := fnv.New64()
+  filter.WriteTo(hasher)
+  return base64.URLEncoding.EncodeToString(hasher.Sum(nil))
 }
 
 func NewBloomReachabilityMap() *BloomReachabilityMap {
@@ -16,8 +32,13 @@ func NewBloomReachabilityMap() *BloomReachabilityMap {
 
 	m := BloomReachabilityMap{
 		Filters:      fs,
+		filter_hashes: make(map[string]bool),
 		Conglomerate: fs[0].Copy(),
 	}
+
+  // Hash our initial filter to begin with.
+  initial_hash := hashFilter(fs[0])
+  m.filter_hashes[initial_hash] = true
 	return &m
 }
 
@@ -39,22 +60,69 @@ func (m *BloomReachabilityMap) Increment() {
 	m.Filters = append(newZeroth, m.Filters...)
 }
 
-func (m *BloomReachabilityMap) Merge(n *BloomReachabilityMap) {
+// Merges two reachability maps.
+// Args:
+//  n: The map to merge with this one.
+// Returns:
+//  True if the map was modified, false if it wasn't. Practically, it will only
+//  return false if it is being asked to merge a map whose filters are a subset
+//  of this one's filters.
+func (m *BloomReachabilityMap) Merge(n *BloomReachabilityMap) bool {
+  modified := false
+
 	if len(m.Filters) < len(n.Filters) {
+    modified = true
 		for k, v := range m.Filters {
+		  _, found := m.filter_hashes[hashFilter(n.Filters[k])]
+      if (found) {
+        // This filter is not new.
+        continue
+      }
+
+		  old_hash := hashFilter(v)
 			v.Merge(n.Filters[k])
+		  new_hash := hashFilter(v)
+		  if old_hash != new_hash {
+        delete(m.filter_hashes, old_hash)
+        m.filter_hashes[new_hash] = true
+      }
 		}
 		// append the remaining Filters
+		for _, filter := range n.Filters[len(m.Filters):] {
+		  m.filter_hashes[hashFilter(filter)] = true
+		}
 		m.Filters = append(m.Filters, n.Filters[len(m.Filters):]...)
 	} else {
 		for k, v := range n.Filters {
+      // Check for an identical filter.
+      _, found := m.filter_hashes[hashFilter(v)]
+      if (found) {
+        // This filter is not new.
+        continue
+      }
+
+      old_hash := hashFilter(m.Filters[k])
 			m.Filters[k].Merge(v)
+			new_hash := hashFilter(m.Filters[k])
+			if old_hash != new_hash {
+        delete(m.filter_hashes, old_hash)
+        m.filter_hashes[new_hash] = true
+        modified = true
+      }
 		}
 	}
+
+	if !modified {
+	  // We didn't add any new filters.
+	  return false
+	}
+
 	// reconstruct the Conglomerate
 	for _, v := range m.Filters {
 		m.Conglomerate.Merge(v)
 	}
+
+	return true
 }
 
 func (m *BloomReachabilityMap) Copy() *BloomReachabilityMap {


### PR DESCRIPTION
Now it hashes maps and doesn't pass duplicate ones along, except
when a new peer comes online. So far, this is experimental, but
it seems to work alright.
